### PR TITLE
fix: accept day-name strings in SystemDayOfWeek unmarshal (v24 + v25)

### DIFF
--- a/v24/api/keyfactor/v1/model_system_day_of_week.go
+++ b/v24/api/keyfactor/v1/model_system_day_of_week.go
@@ -79,20 +79,31 @@ var AllowedSystemDayOfWeekEnumValues = []SystemDayOfWeek{
 }
 
 func (v *SystemDayOfWeek) UnmarshalJSON(src []byte) error {
+	// Keyfactor Command has, across API versions, serialized this enum both
+	// as a JSON integer (e.g. 1) and as a day-name string (e.g. "Monday").
+	// Try the integer form first to preserve the original generated
+	// validation against AllowedSystemDayOfWeekEnumValues.
 	var value int32
-	err := json.Unmarshal(src, &value)
-	if err != nil {
-		return err
-	}
-	enumTypeValue := SystemDayOfWeek(value)
-	for _, existing := range AllowedSystemDayOfWeekEnumValues {
-		if existing == enumTypeValue {
-			*v = enumTypeValue
-			return nil
+	if err := json.Unmarshal(src, &value); err == nil {
+		enumTypeValue := SystemDayOfWeek(value)
+		for _, existing := range AllowedSystemDayOfWeekEnumValues {
+			if existing == enumTypeValue {
+				*v = enumTypeValue
+				return nil
+			}
 		}
+
+		return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
 	}
 
-	return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
+	// Fall back to the string form (e.g. "Monday") using the existing Parse
+	// helper, which maps day names to their enum values.
+	var strValue string
+	if err := json.Unmarshal(src, &strValue); err != nil {
+		return fmt.Errorf("SystemDayOfWeek must be a JSON integer or day-name string, got %s", string(src))
+	}
+
+	return v.Parse(strValue)
 }
 
 // NewSystemDayOfWeekFromValue returns a pointer to a valid SystemDayOfWeek

--- a/v24/api/keyfactor/v1/model_system_day_of_week_test.go
+++ b/v24/api/keyfactor/v1/model_system_day_of_week_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 Keyfactor
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.  You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0.  Unless
+required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+the specific language governing permissions and limitations under the
+License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestSystemDayOfWeek_UnmarshalJSON_IntForm verifies that the original
+// generated wire form (a JSON integer) still deserializes correctly.
+func TestSystemDayOfWeek_UnmarshalJSON_IntForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`1`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling int form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_StringForm covers the regression from
+// GitHub issue #185: Keyfactor Command v25.5 serializes WeeklyModel.Days as
+// day-name strings (e.g. "Monday") rather than integers.
+func TestSystemDayOfWeek_UnmarshalJSON_StringForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`"Monday"`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling string form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_InvalidString verifies a malformed day
+// name still produces a clear error rather than silently defaulting.
+func TestSystemDayOfWeek_UnmarshalJSON_InvalidString(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`"Funday"`), &got)
+	if err == nil {
+		t.Fatalf("expected error for invalid day-name string, got nil (value=%v)", got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt verifies an out-of-range
+// integer still produces a clear error rather than silently accepting it.
+func TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`42`), &got)
+	if err == nil {
+		t.Fatalf("expected error for out-of-range int, got nil (value=%v)", got)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayNameStrings is the full round-trip
+// regression test for issue #185: a Weekly-shaped schedule payload as
+// returned by GET /CertificateAuthority on a v25.5 Command instance must
+// deserialize into KeyfactorCommonSchedulingModelsWeeklyModel without error.
+func TestWeeklyModel_UnmarshalJSON_DayNameStrings(t *testing.T) {
+	payload := `{"Days":["Monday","Friday"],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with day-name strings: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+
+	wantTime, err := time.Parse(time.RFC3339, "2000-01-01T07:00:00Z")
+	if err != nil {
+		t.Fatalf("failed to parse expected time: %v", err)
+	}
+	if model.Time == nil || !model.Time.Equal(wantTime) {
+		t.Errorf("Time: expected %v, got %v", wantTime, model.Time)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayIndexInts verifies the pre-v25.5 integer
+// wire form of WeeklyModel.Days still round-trips correctly, guarding
+// against a regression in the other direction.
+func TestWeeklyModel_UnmarshalJSON_DayIndexInts(t *testing.T) {
+	payload := `{"Days":[1,5],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with int days: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+}

--- a/v24/api/keyfactor/v2/model_system_day_of_week.go
+++ b/v24/api/keyfactor/v2/model_system_day_of_week.go
@@ -79,20 +79,31 @@ var AllowedSystemDayOfWeekEnumValues = []SystemDayOfWeek{
 }
 
 func (v *SystemDayOfWeek) UnmarshalJSON(src []byte) error {
+	// Keyfactor Command has, across API versions, serialized this enum both
+	// as a JSON integer (e.g. 1) and as a day-name string (e.g. "Monday").
+	// Try the integer form first to preserve the original generated
+	// validation against AllowedSystemDayOfWeekEnumValues.
 	var value int32
-	err := json.Unmarshal(src, &value)
-	if err != nil {
-		return err
-	}
-	enumTypeValue := SystemDayOfWeek(value)
-	for _, existing := range AllowedSystemDayOfWeekEnumValues {
-		if existing == enumTypeValue {
-			*v = enumTypeValue
-			return nil
+	if err := json.Unmarshal(src, &value); err == nil {
+		enumTypeValue := SystemDayOfWeek(value)
+		for _, existing := range AllowedSystemDayOfWeekEnumValues {
+			if existing == enumTypeValue {
+				*v = enumTypeValue
+				return nil
+			}
 		}
+
+		return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
 	}
 
-	return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
+	// Fall back to the string form (e.g. "Monday") using the existing Parse
+	// helper, which maps day names to their enum values.
+	var strValue string
+	if err := json.Unmarshal(src, &strValue); err != nil {
+		return fmt.Errorf("SystemDayOfWeek must be a JSON integer or day-name string, got %s", string(src))
+	}
+
+	return v.Parse(strValue)
 }
 
 // NewSystemDayOfWeekFromValue returns a pointer to a valid SystemDayOfWeek

--- a/v24/api/keyfactor/v2/model_system_day_of_week_test.go
+++ b/v24/api/keyfactor/v2/model_system_day_of_week_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 Keyfactor
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.  You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0.  Unless
+required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+the specific language governing permissions and limitations under the
+License.
+*/
+
+package v2
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestSystemDayOfWeek_UnmarshalJSON_IntForm verifies that the original
+// generated wire form (a JSON integer) still deserializes correctly.
+func TestSystemDayOfWeek_UnmarshalJSON_IntForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`1`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling int form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_StringForm covers the regression from
+// GitHub issue #185: Keyfactor Command v25.5 serializes WeeklyModel.Days as
+// day-name strings (e.g. "Monday") rather than integers.
+func TestSystemDayOfWeek_UnmarshalJSON_StringForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`"Monday"`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling string form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_InvalidString verifies a malformed day
+// name still produces a clear error rather than silently defaulting.
+func TestSystemDayOfWeek_UnmarshalJSON_InvalidString(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`"Funday"`), &got)
+	if err == nil {
+		t.Fatalf("expected error for invalid day-name string, got nil (value=%v)", got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt verifies an out-of-range
+// integer still produces a clear error rather than silently accepting it.
+func TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`42`), &got)
+	if err == nil {
+		t.Fatalf("expected error for out-of-range int, got nil (value=%v)", got)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayNameStrings is the full round-trip
+// regression test for issue #185: a Weekly-shaped schedule payload as
+// returned by GET /CertificateAuthority on a v25.5 Command instance must
+// deserialize into KeyfactorCommonSchedulingModelsWeeklyModel without error.
+func TestWeeklyModel_UnmarshalJSON_DayNameStrings(t *testing.T) {
+	payload := `{"Days":["Monday","Friday"],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with day-name strings: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+
+	wantTime, err := time.Parse(time.RFC3339, "2000-01-01T07:00:00Z")
+	if err != nil {
+		t.Fatalf("failed to parse expected time: %v", err)
+	}
+	if model.Time == nil || !model.Time.Equal(wantTime) {
+		t.Errorf("Time: expected %v, got %v", wantTime, model.Time)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayIndexInts verifies the pre-v25.5 integer
+// wire form of WeeklyModel.Days still round-trips correctly, guarding
+// against a regression in the other direction.
+func TestWeeklyModel_UnmarshalJSON_DayIndexInts(t *testing.T) {
+	payload := `{"Days":[1,5],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with int days: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+}

--- a/v25/api/keyfactor/v1/model_system_day_of_week.go
+++ b/v25/api/keyfactor/v1/model_system_day_of_week.go
@@ -79,20 +79,31 @@ var AllowedSystemDayOfWeekEnumValues = []SystemDayOfWeek{
 }
 
 func (v *SystemDayOfWeek) UnmarshalJSON(src []byte) error {
+	// Keyfactor Command has, across API versions, serialized this enum both
+	// as a JSON integer (e.g. 1) and as a day-name string (e.g. "Monday").
+	// Try the integer form first to preserve the original generated
+	// validation against AllowedSystemDayOfWeekEnumValues.
 	var value int32
-	err := json.Unmarshal(src, &value)
-	if err != nil {
-		return err
-	}
-	enumTypeValue := SystemDayOfWeek(value)
-	for _, existing := range AllowedSystemDayOfWeekEnumValues {
-		if existing == enumTypeValue {
-			*v = enumTypeValue
-			return nil
+	if err := json.Unmarshal(src, &value); err == nil {
+		enumTypeValue := SystemDayOfWeek(value)
+		for _, existing := range AllowedSystemDayOfWeekEnumValues {
+			if existing == enumTypeValue {
+				*v = enumTypeValue
+				return nil
+			}
 		}
+
+		return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
 	}
 
-	return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
+	// Fall back to the string form (e.g. "Monday") using the existing Parse
+	// helper, which maps day names to their enum values.
+	var strValue string
+	if err := json.Unmarshal(src, &strValue); err != nil {
+		return fmt.Errorf("SystemDayOfWeek must be a JSON integer or day-name string, got %s", string(src))
+	}
+
+	return v.Parse(strValue)
 }
 
 // NewSystemDayOfWeekFromValue returns a pointer to a valid SystemDayOfWeek

--- a/v25/api/keyfactor/v1/model_system_day_of_week_test.go
+++ b/v25/api/keyfactor/v1/model_system_day_of_week_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 Keyfactor
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.  You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0.  Unless
+required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+the specific language governing permissions and limitations under the
+License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestSystemDayOfWeek_UnmarshalJSON_IntForm verifies that the original
+// generated wire form (a JSON integer) still deserializes correctly.
+func TestSystemDayOfWeek_UnmarshalJSON_IntForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`1`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling int form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_StringForm covers the regression from
+// GitHub issue #185: Keyfactor Command v25.5 serializes WeeklyModel.Days as
+// day-name strings (e.g. "Monday") rather than integers.
+func TestSystemDayOfWeek_UnmarshalJSON_StringForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`"Monday"`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling string form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_InvalidString verifies a malformed day
+// name still produces a clear error rather than silently defaulting.
+func TestSystemDayOfWeek_UnmarshalJSON_InvalidString(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`"Funday"`), &got)
+	if err == nil {
+		t.Fatalf("expected error for invalid day-name string, got nil (value=%v)", got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt verifies an out-of-range
+// integer still produces a clear error rather than silently accepting it.
+func TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`42`), &got)
+	if err == nil {
+		t.Fatalf("expected error for out-of-range int, got nil (value=%v)", got)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayNameStrings is the full round-trip
+// regression test for issue #185: a Weekly-shaped schedule payload as
+// returned by GET /CertificateAuthority on a v25.5 Command instance must
+// deserialize into KeyfactorCommonSchedulingModelsWeeklyModel without error.
+func TestWeeklyModel_UnmarshalJSON_DayNameStrings(t *testing.T) {
+	payload := `{"Days":["Monday","Friday"],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with day-name strings: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+
+	wantTime, err := time.Parse(time.RFC3339, "2000-01-01T07:00:00Z")
+	if err != nil {
+		t.Fatalf("failed to parse expected time: %v", err)
+	}
+	if model.Time == nil || !model.Time.Equal(wantTime) {
+		t.Errorf("Time: expected %v, got %v", wantTime, model.Time)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayIndexInts verifies the pre-v25.5 integer
+// wire form of WeeklyModel.Days still round-trips correctly, guarding
+// against a regression in the other direction.
+func TestWeeklyModel_UnmarshalJSON_DayIndexInts(t *testing.T) {
+	payload := `{"Days":[1,5],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with int days: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+}

--- a/v25/api/keyfactor/v2/model_system_day_of_week.go
+++ b/v25/api/keyfactor/v2/model_system_day_of_week.go
@@ -79,20 +79,31 @@ var AllowedSystemDayOfWeekEnumValues = []SystemDayOfWeek{
 }
 
 func (v *SystemDayOfWeek) UnmarshalJSON(src []byte) error {
+	// Keyfactor Command has, across API versions, serialized this enum both
+	// as a JSON integer (e.g. 1) and as a day-name string (e.g. "Monday").
+	// Try the integer form first to preserve the original generated
+	// validation against AllowedSystemDayOfWeekEnumValues.
 	var value int32
-	err := json.Unmarshal(src, &value)
-	if err != nil {
-		return err
-	}
-	enumTypeValue := SystemDayOfWeek(value)
-	for _, existing := range AllowedSystemDayOfWeekEnumValues {
-		if existing == enumTypeValue {
-			*v = enumTypeValue
-			return nil
+	if err := json.Unmarshal(src, &value); err == nil {
+		enumTypeValue := SystemDayOfWeek(value)
+		for _, existing := range AllowedSystemDayOfWeekEnumValues {
+			if existing == enumTypeValue {
+				*v = enumTypeValue
+				return nil
+			}
 		}
+
+		return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
 	}
 
-	return fmt.Errorf("%+v is not a valid SystemDayOfWeek", value)
+	// Fall back to the string form (e.g. "Monday") using the existing Parse
+	// helper, which maps day names to their enum values.
+	var strValue string
+	if err := json.Unmarshal(src, &strValue); err != nil {
+		return fmt.Errorf("SystemDayOfWeek must be a JSON integer or day-name string, got %s", string(src))
+	}
+
+	return v.Parse(strValue)
 }
 
 // NewSystemDayOfWeekFromValue returns a pointer to a valid SystemDayOfWeek

--- a/v25/api/keyfactor/v2/model_system_day_of_week_test.go
+++ b/v25/api/keyfactor/v2/model_system_day_of_week_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 Keyfactor
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License.  You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0.  Unless
+required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+the specific language governing permissions and limitations under the
+License.
+*/
+
+package v2
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestSystemDayOfWeek_UnmarshalJSON_IntForm verifies that the original
+// generated wire form (a JSON integer) still deserializes correctly.
+func TestSystemDayOfWeek_UnmarshalJSON_IntForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`1`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling int form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_StringForm covers the regression from
+// GitHub issue #185: Keyfactor Command v25.5 serializes WeeklyModel.Days as
+// day-name strings (e.g. "Monday") rather than integers.
+func TestSystemDayOfWeek_UnmarshalJSON_StringForm(t *testing.T) {
+	var got SystemDayOfWeek
+	if err := json.Unmarshal([]byte(`"Monday"`), &got); err != nil {
+		t.Fatalf("unexpected error unmarshaling string form: %v", err)
+	}
+	if got != SYSTEMDAYOFWEEK_Monday {
+		t.Errorf("expected %v, got %v", SYSTEMDAYOFWEEK_Monday, got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_InvalidString verifies a malformed day
+// name still produces a clear error rather than silently defaulting.
+func TestSystemDayOfWeek_UnmarshalJSON_InvalidString(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`"Funday"`), &got)
+	if err == nil {
+		t.Fatalf("expected error for invalid day-name string, got nil (value=%v)", got)
+	}
+}
+
+// TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt verifies an out-of-range
+// integer still produces a clear error rather than silently accepting it.
+func TestSystemDayOfWeek_UnmarshalJSON_OutOfRangeInt(t *testing.T) {
+	var got SystemDayOfWeek
+	err := json.Unmarshal([]byte(`42`), &got)
+	if err == nil {
+		t.Fatalf("expected error for out-of-range int, got nil (value=%v)", got)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayNameStrings is the full round-trip
+// regression test for issue #185: a Weekly-shaped schedule payload as
+// returned by GET /CertificateAuthority on a v25.5 Command instance must
+// deserialize into KeyfactorCommonSchedulingModelsWeeklyModel without error.
+func TestWeeklyModel_UnmarshalJSON_DayNameStrings(t *testing.T) {
+	payload := `{"Days":["Monday","Friday"],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with day-name strings: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+
+	wantTime, err := time.Parse(time.RFC3339, "2000-01-01T07:00:00Z")
+	if err != nil {
+		t.Fatalf("failed to parse expected time: %v", err)
+	}
+	if model.Time == nil || !model.Time.Equal(wantTime) {
+		t.Errorf("Time: expected %v, got %v", wantTime, model.Time)
+	}
+}
+
+// TestWeeklyModel_UnmarshalJSON_DayIndexInts verifies the pre-v25.5 integer
+// wire form of WeeklyModel.Days still round-trips correctly, guarding
+// against a regression in the other direction.
+func TestWeeklyModel_UnmarshalJSON_DayIndexInts(t *testing.T) {
+	payload := `{"Days":[1,5],"Time":"2000-01-01T07:00:00Z"}`
+
+	var model KeyfactorCommonSchedulingModelsWeeklyModel
+	if err := json.Unmarshal([]byte(payload), &model); err != nil {
+		t.Fatalf("unexpected error unmarshaling WeeklyModel with int days: %v", err)
+	}
+
+	wantDays := []SystemDayOfWeek{SYSTEMDAYOFWEEK_Monday, SYSTEMDAYOFWEEK_Friday}
+	if len(model.Days) != len(wantDays) {
+		t.Fatalf("expected %d days, got %d (%v)", len(wantDays), len(model.Days), model.Days)
+	}
+	for i, want := range wantDays {
+		if model.Days[i] != want {
+			t.Errorf("Days[%d]: expected %v, got %v", i, want, model.Days[i])
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`SystemDayOfWeek.UnmarshalJSON` only accepts a JSON integer, but Keyfactor Command (observed on v25.5) serializes `WeeklyModel.Days` as day-name strings (e.g. `["Monday"]`) in `GET /CertificateAuthority` responses. Any Weekly-shaped CA schedule therefore fails to deserialize, which breaks every subsequent Read/Update of that CA in downstream consumers.

Tracked downstream as keyfactor-pub/terraform-provider-keyfactor#185.

## Fix

`UnmarshalJSON` now tries the integer form first (preserving the original validation against `AllowedSystemDayOfWeekEnumValues` and its error message), then falls back to the string form via the existing `Parse()` day-name mapper. A payload that is neither a valid JSON integer nor a JSON string returns a clear error.

Applied identically to all four generated copies: `v24/api/keyfactor/{v1,v2}` and `v25/api/keyfactor/{v1,v2}`.

## Verification

- New unit tests in each of the four packages: int form, string form, invalid string, out-of-range int, plus full `WeeklyModel` round-trips for both `{"Days":["Monday","Friday"],...}` and int-index forms.
- Red→green confirmed: with the fix reverted, the string-form tests fail with `json: cannot unmarshal string into Go value of type int32`.
- Full `go test ./...` green in both the v24 and v25 modules (with `-vet=off` due to a pre-existing, unrelated `fmt.Errorf` non-constant-format vet error in `configuration.go` on `main`).

## Notes

- The `feat/sdk-v25-migration` branch generates this file from the shared `custom-templates/go/model_enum.mustache`, which still has the int-only unmarshal — that template will need the equivalent fallback when the migration branch is picked back up. That template is shared by ~80+ int-backed enums (all of which have unused `Parse()` string helpers), so a blanket template change deserves its own discussion; this PR deliberately fixes only the enum with an observed wire regression.